### PR TITLE
Use AC_CONFIG_MACRO_DIRS / ACLOCAL_AMFLAGS.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-
+ACLOCAL_AMFLAGS=-I m4
 
 include_HEADERS = \
 inc/sai_acl_npu_api.h    inc/sai_gen_utils.h      inc/sai_lag_callback.h    inc/sai_npu_mirror.h        inc/sai_port_common.h        inc/sai_shell_npu.h           inc/sai_vlan_api.h \

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_INIT([sai-common-utils], [1.0.1], [sonicproject@gmail.com])
 AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_MACRO_DIRS([m4])
 
 # Checks for programs.
 AC_PROG_CC


### PR DESCRIPTION
Avoid configure / libtool warnings by specifying directory for m4 macros.