### PR TITLE
Copyright and License update

### DIFF
--- a/inc/sai_acl_npu_api.h
+++ b/inc/sai_acl_npu_api.h
@@ -1,13 +1,19 @@
-/************************************************************************
- * * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
- * *
- * * This source code is confidential, proprietary, and contains trade
- * * secrets that are the sole property of Dell Inc.
- * * Copy and/or distribution of this source code or disassembly or reverse
- * * engineering of the resultant object code are strictly forbidden without
- * * the written consent of Dell Inc.
- * *
- * ************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
  * * @file sai_acl_npu_api.h
  * *

--- a/inc/sai_acl_type_defs.h
+++ b/inc/sai_acl_type_defs.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_acl_type_defs.h
 *

--- a/inc/sai_acl_utils.h
+++ b/inc/sai_acl_utils.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_acl_utils.h
 *

--- a/inc/sai_common_utils.h
+++ b/inc/sai_common_utils.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_common_utils.h
 *

--- a/inc/sai_debug_utils.h
+++ b/inc/sai_debug_utils.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_debug_utils.h
 *

--- a/inc/sai_event_log.h
+++ b/inc/sai_event_log.h
@@ -1,13 +1,19 @@
-/************************************************************************
- * LEGALESE:   Copyright (c) 1999-2014, Dell Inc
+/*
+ * Copyright (c) 2016 Dell Inc.
  *
- * This source code is confidential, proprietary, and contains trade
- * secrets that are the sole property of Dell Inc.
- * Copy and/or distribution of this source code or disassembly or reverse
- * engineering of the resultant object code are strictly forbidden without
- * the written consent of Dell Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  *
- ************************************************************************
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
  */
 /*!
  * \file   sai_event_log.h

--- a/inc/sai_fdb_api.h
+++ b/inc/sai_fdb_api.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /***
  * \file    sai_fdb_api.h
  *

--- a/inc/sai_fdb_common.h
+++ b/inc/sai_fdb_common.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /***
  * \file    sai_fdb_common.h
  *

--- a/inc/sai_gen_utils.h
+++ b/inc/sai_gen_utils.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /***
  * \file    sai_gen_utils.h
  *

--- a/inc/sai_hash_object.h
+++ b/inc/sai_hash_object.h
@@ -1,13 +1,3 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2016, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
 /**
 * @file sai_hash_object.h
 *
@@ -119,4 +109,20 @@ typedef struct _dn_sai_hash_obj_db_t {
 
 
 #endif /*__SAI_HASH_COMMON_H__*/
+
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
 

--- a/inc/sai_hostif_common.h
+++ b/inc/sai_hostif_common.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_hostif_common.h
 *

--- a/inc/sai_infra_api.h
+++ b/inc/sai_infra_api.h
@@ -1,9 +1,23 @@
 /*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
  *  * filename:sai_infra_api.h
- *  * (c) Copyright 2014 Dell Inc. All Rights Reserved.
  *  */
 
-/** OPENSOURCELICENSE */
 
 #ifndef __SAI_INFRA_API_H
 #define __SAI_INFRA_API_H

--- a/inc/sai_l3_api.h
+++ b/inc/sai_l3_api.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_l3_api.h
 *

--- a/inc/sai_l3_common.h
+++ b/inc/sai_l3_common.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_l3_common.h
 *

--- a/inc/sai_l3_util.h
+++ b/inc/sai_l3_util.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_l3_util.h
 *

--- a/inc/sai_lag_api.h
+++ b/inc/sai_lag_api.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /***
  * \file    sai_lag_api.h
  *

--- a/inc/sai_lag_callback.h
+++ b/inc/sai_lag_callback.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /***
  * \file    sai_lag_callback.h
  *

--- a/inc/sai_lag_common.h
+++ b/inc/sai_lag_common.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /***
  * \file    sai_lag_common.h
  *

--- a/inc/sai_mirror_defs.h
+++ b/inc/sai_mirror_defs.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_mirror_defs.h
 *

--- a/inc/sai_mirror_util.h
+++ b/inc/sai_mirror_util.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_mirror_util.h
 *

--- a/inc/sai_npu_api_plugin.h
+++ b/inc/sai_npu_api_plugin.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_npu_api_plugin.h
 *

--- a/inc/sai_npu_fdb.h
+++ b/inc/sai_npu_fdb.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /***
  * \file    sai_npu_fdb.h
  *

--- a/inc/sai_npu_hostif.h
+++ b/inc/sai_npu_hostif.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /***
  * @file  sai_npu_hostif.h
  *

--- a/inc/sai_npu_lag.h
+++ b/inc/sai_npu_lag.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /***
  * \file    sai_npu_lag.h
  *

--- a/inc/sai_npu_mirror.h
+++ b/inc/sai_npu_mirror.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
  * @file    sai_npu_mirror.h
  *

--- a/inc/sai_npu_port.h
+++ b/inc/sai_npu_port.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c); 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_npu_port.h
 *

--- a/inc/sai_npu_qos.h
+++ b/inc/sai_npu_qos.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_npu_qos.h
 *

--- a/inc/sai_npu_samplepacket.h
+++ b/inc/sai_npu_samplepacket.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
  * @file    sai_npu_samplepacket.h
  *

--- a/inc/sai_npu_stp.h
+++ b/inc/sai_npu_stp.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
  * @file    sai_npu_stp.h
  *

--- a/inc/sai_npu_switch.h
+++ b/inc/sai_npu_switch.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c); 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_npu_switch.h
 *

--- a/inc/sai_npu_vlan.h
+++ b/inc/sai_npu_vlan.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /***
  * \file    sai_npu_vlan.h
  *

--- a/inc/sai_oid_utils.h
+++ b/inc/sai_oid_utils.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_oid_utils.h
 *

--- a/inc/sai_port_common.h
+++ b/inc/sai_port_common.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_port_common.h
 *

--- a/inc/sai_port_utils.h
+++ b/inc/sai_port_utils.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c); 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_port_utils.h
 *

--- a/inc/sai_qos_buffer_util.h
+++ b/inc/sai_qos_buffer_util.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_qos_buffer_util.h
 *

--- a/inc/sai_qos_common.h
+++ b/inc/sai_qos_common.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_qos_common.h
 *

--- a/inc/sai_qos_util.h
+++ b/inc/sai_qos_util.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_qos_util.h
 *

--- a/inc/sai_samplepacket_defs.h
+++ b/inc/sai_samplepacket_defs.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_samplepacket_defs.h
 *

--- a/inc/sai_samplepacket_util.h
+++ b/inc/sai_samplepacket_util.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_samplepacket_util.h
 *

--- a/inc/sai_shell.h
+++ b/inc/sai_shell.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
  * \file    sai_shell.h
  *

--- a/inc/sai_shell_npu.h
+++ b/inc/sai_shell_npu.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /***
  * \file    sai_shell_npu.h
  *

--- a/inc/sai_stp_defs.h
+++ b/inc/sai_stp_defs.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_stp_defs.h
 *

--- a/inc/sai_stp_util.h
+++ b/inc/sai_stp_util.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_stp_util.h
 *

--- a/inc/sai_switch_common.h
+++ b/inc/sai_switch_common.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_switch_common.h
 *

--- a/inc/sai_switch_init_config.h
+++ b/inc/sai_switch_init_config.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_switch_init_config.h
 *

--- a/inc/sai_switch_utils.h
+++ b/inc/sai_switch_utils.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c); 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_switch_utils.h
 *

--- a/inc/sai_udf_common.h
+++ b/inc/sai_udf_common.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_udf_common.h
 *

--- a/inc/sai_udf_npu_api.h
+++ b/inc/sai_udf_npu_api.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_udf_npu_api.h
 *

--- a/inc/sai_vlan_api.h
+++ b/inc/sai_vlan_api.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /***
  * \file    sai_vlan_api.h
  *

--- a/inc/sai_vlan_common.h
+++ b/inc/sai_vlan_common.h
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /***
  * \file    sai_vlan_common.h
  *

--- a/src/acl/sai_acl_utils.c
+++ b/src/acl/sai_acl_utils.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_acl_utils.c
 *

--- a/src/port/sai_port_attributes.c
+++ b/src/port/sai_port_attributes.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_port_attributes.c
 *

--- a/src/port/sai_port_debug.c
+++ b/src/port/sai_port_debug.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_port_debug.c
 *

--- a/src/port/sai_port_utils.c
+++ b/src/port/sai_port_utils.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_port_utils.c
 *

--- a/src/qos/sai_qos_buffer_util.c
+++ b/src/qos/sai_qos_buffer_util.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_qos_buffer_util.c
 *

--- a/src/qos/sai_qos_debug.c
+++ b/src/qos/sai_qos_debug.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_qos_debug.c
 *

--- a/src/qos/sai_qos_maps_debug.c
+++ b/src/qos/sai_qos_maps_debug.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file  sai_qos_maps_debug.c
 *

--- a/src/qos/sai_qos_policer_debugs.c
+++ b/src/qos/sai_qos_policer_debugs.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file  sai_qos_policer_debug.c
 *

--- a/src/qos/sai_qos_util.c
+++ b/src/qos/sai_qos_util.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_qos_util.c
 *

--- a/src/qos/sai_qos_wred_debugs.c
+++ b/src/qos/sai_qos_wred_debugs.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file  sai_qos_wred_debugs.c
 *

--- a/src/routing/sai_l3_debug.c
+++ b/src/routing/sai_l3_debug.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file  sai_l3_debug.c
 *

--- a/src/routing/sai_l3_init.c
+++ b/src/routing/sai_l3_init.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_l3_init.c
 *

--- a/src/routing/sai_l3_util.c
+++ b/src/routing/sai_l3_util.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_l3_util.c
 *

--- a/src/sai_gen_utils.c
+++ b/src/sai_gen_utils.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_gen_utils.c
 *

--- a/src/switchinfra/sai_switch_debug.c
+++ b/src/switchinfra/sai_switch_debug.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_switch_debug.c
 *

--- a/src/switchinfra/sai_switch_utils.c
+++ b/src/switchinfra/sai_switch_utils.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-*
-* This source code is confidential, proprietary, and contains trade
-* secrets that are the sole property of Dell Inc.
-* Copy and/or distribution of this source code or disassembly or reverse
-* engineering of the resultant object code are strictly forbidden without
-* the written consent of Dell Inc.
-*
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_switch_utils.c
 *

--- a/src/switching/sai_fdb_debug.c
+++ b/src/switching/sai_fdb_debug.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_fdb_debug.c
 *

--- a/src/switching/sai_fdb_utils.c
+++ b/src/switching/sai_fdb_utils.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_fdb_utils.c
 *

--- a/src/switching/sai_lag_debug.c
+++ b/src/switching/sai_lag_debug.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_lag_debug.c
 *

--- a/src/switching/sai_lag_utils.c
+++ b/src/switching/sai_lag_utils.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_lag_utils.c
 *

--- a/src/switching/sai_vlan_debug.c
+++ b/src/switching/sai_vlan_debug.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_vlan_debug.c
 *

--- a/src/switching/sai_vlan_utils.c
+++ b/src/switching/sai_vlan_utils.c
@@ -1,13 +1,19 @@
-/************************************************************************
-* * LEGALESE:   "Copyright (c) 2015, Dell Inc. All rights reserved."
-* *
-* * This source code is confidential, proprietary, and contains trade
-* * secrets that are the sole property of Dell Inc.
-* * Copy and/or distribution of this source code or disassembly or reverse
-* * engineering of the resultant object code are strictly forbidden without
-* * the written consent of Dell Inc.
-* *
-************************************************************************/
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
 /**
 * @file sai_vlan_utils.c
 *


### PR DESCRIPTION
Because copyright and license of code-files mismatched LICENSE-file in
root directory, I changed copyright comment in each file to 2016 and license
to Apache 2.0.

I do not know, whether these changes are legitimate, but the mismatch with the root-LICENSE and terms like "distribution of this source code [...] strictly forbidden" confused me a little, so I think it might be a mistake.